### PR TITLE
debian/control: adjust go dependency version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Misty De Meo <mdemeo@artefactual.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.3
-Build-Depends: debhelper (>= 9), golang-go (>= 2:1.2), dh-golang,
+Build-Depends: debhelper (>= 9), golang-go (>= 2:1.1), dh-golang,
  golang-richardlehane-match-dev, golang-richardlehane-mscfb-dev
 
 Package: siegfried


### PR DESCRIPTION
Also filed equivalent PRs in the other go modules.
