### PR TITLE
roy: check for arg length before slicing

### DIFF
--- a/cmd/roy/roy.go
+++ b/cmd/roy/roy.go
@@ -221,6 +221,10 @@ Usage
 
 func main() {
 	var err error
+	if len(os.Args) < 2 {
+		log.Fatal(usage)
+	}
+
 	switch os.Args[1] {
 	case "build":
 		err = build.Parse(os.Args[2:])


### PR DESCRIPTION
If `roy` is run with no arguments, it currently exits with an error since the `1` index is out of bounds.
