### PR TITLE
Update required go version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,7 @@ Maintainer: Misty De Meo <mdemeo@artefactual.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.3
-Build-Depends: debhelper (>= 9), golang-go (>= 2:1.5), dh-golang,
- golang-richardlehane-match-dev, golang-richardlehane-mscfb-dev
+Build-Depends: debhelper (>= 9), golang-go (>= 2:1.5), dh-golang
 
 Package: siegfried
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Misty De Meo <mdemeo@artefactual.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.3
-Build-Depends: debhelper (>= 9), golang-go (>= 2:1.1), dh-golang,
+Build-Depends: debhelper (>= 9), golang-go (>= 2:1.5), dh-golang,
  golang-richardlehane-match-dev, golang-richardlehane-mscfb-dev
 
 Package: siegfried


### PR DESCRIPTION
Since vendored dependencies are now used, this should mark go 1.5 or newer as a dependency.