### PR TITLE
Ensure that SF doesn't hang w/o user read perms

### DIFF
--- a/cmd/sf/longpath.go
+++ b/cmd/sf/longpath.go
@@ -55,6 +55,11 @@ func identify(ctxts chan *context, root, orig string, coerr, norecurse, droid bo
 			printFile(ctxts, gf(path, "", info.ModTime().Format(time.RFC3339), info.Size()), ModeError(info.Mode()))
 			return nil
 		}
+		// zero user read permissions mask, octal 400 (decimal 256)
+		if info.Mode()&(256) == 0 {
+			printFile(ctxts, gf(path, "", info.ModTime().Format(time.RFC3339), info.Size()), ModeError(info.Mode()))
+			return nil
+		}
 		identifyFile(gf(path, "", info.ModTime().Format(time.RFC3339), info.Size()), ctxts, gf)
 		return nil
 	}

--- a/cmd/sf/sf.go
+++ b/cmd/sf/sf.go
@@ -70,8 +70,18 @@ var (
 
 type ModeError os.FileMode
 
+func declarative_lookup(dtyp int, typ string) string {
+	decl := "file is of type %s; only regular files can be scanned"
+	switch {
+	case dtyp == 1:
+		decl = "file does not have %s; and cannot be scanned"
+	}
+	return fmt.Sprintf(decl, typ)
+}
+
 func (me ModeError) Error() string {
 	typ := "unknown"
+	dtyp := 0
 	switch {
 	case os.FileMode(me)&os.ModeDir == os.ModeDir:
 		typ = "directory"
@@ -83,8 +93,11 @@ func (me ModeError) Error() string {
 		typ = "socket"
 	case os.FileMode(me)&os.ModeDevice == os.ModeDevice:
 		typ = "device"
+	case os.FileMode(me)&(256) == 0:
+		typ = "user read permissions"
+		dtyp = 1
 	}
-	return fmt.Sprintf("file is of type %s; only regular files can be scanned", typ)
+	return declarative_lookup(dtyp, typ)
 }
 
 type WalkError struct {


### PR DESCRIPTION
* Resolves https://github.com/richardlehane/siegfried/issues/113

User will see the following output if they/SF does not have relevant user permissions:
```
[FILE] /home/ross-spencer/git/go/src/github.com/richardlehane/siegfried/cmd/sf/cantwrite
[ERROR] file does not have user read permissions; and cannot be scanned
---
siegfried   : 1.7.8
scandate    : 2018-05-25T11:41:00+02:00
signature   : default.sig
created     : 2017-12-02T14:49:35+11:00
identifiers : 
  - name    : 'pronom'
    details : 'DROID_SignatureFile_V93.xml; container-signature-20171130.xml'
  - name    : 'tika'
    details : 'tika-mimetypes.xml (1.16, 2017-07-07)'
  - name    : 'freedesktop.org'
    details : 'freedesktop.org.xml (1.9, 2017-09-18)'
  - name    : 'loc'
    details : 'fddXML.zip (2017-09-28, DROID_SignatureFile_V93.xml, container-signature-20171130.xml)'
---
filename : 'cantwrite'
filesize : 0
modified : 2018-05-25T10:53:20+02:00
errors   : 'file does not have user read permissions; and cannot be scanned'
matches  :
```