### PR TITLE
Add -nopronom flag to inspect command

### DIFF
--- a/cmd/roy/roy.go
+++ b/cmd/roy/roy.go
@@ -126,7 +126,7 @@ var (
 	locfdd        = build.Bool("loc", false, "build a LOC FDD signature file")
 	wikidata      = build.Bool("wikidata", false, "build a Wikidata identifier")
 	wikidataDebug = build.Bool("wikidatadebug", false, "build a Wikidata identifier in debug mode")
-	nopronom      = build.Bool("nopronom", false, "don't include PRONOM sigs with LOC or Wikidata signature file")
+	noPRONOM      = build.Bool("nopronom", false, "don't include PRONOM sigs with LOC or Wikidata signature file")
 	container     = build.String("container", config.Container(), "set name/path for Droid Container signature file")
 	name          = build.String("name", "", "set identifier name")
 	details       = build.String("details", config.Details(), "set identifier details")
@@ -180,6 +180,7 @@ var (
 	inspectCType    = inspect.Int("ct", 0, "provide container type to inspect container hits")
 	inspectCName    = inspect.String("cn", "", "provide container name to inspect container hits")
 	inspectWikidata = inspect.Bool("wikidata", false, "inspect a Wikidata signature file")
+	inspectNoPRONOM = inspect.Bool("nopronom", false, "don't include PRONOM sigs when inspecting LOC or Wikidata signature file")
 
 	// SETS
 	setsf       = flag.NewFlagSet("sets", flag.ExitOnError)
@@ -348,7 +349,7 @@ func getOptions() []config.Option {
 	if *wikidataDebug {
 		opts = append(opts, config.SetWikidataDebug())
 	}
-	if *nopronom {
+	if *noPRONOM || *inspectNoPRONOM {
 		opts = append(opts, config.SetNoPRONOM())
 		opts = append(opts, config.SetWikidataNoPRONOM())
 	}

--- a/cmd/roy/roy_test.go
+++ b/cmd/roy/roy_test.go
@@ -263,3 +263,38 @@ func TestAddEndpoint(t *testing.T) {
 		)
 	}
 }
+
+// invokeOptions cycles through an options slice and invokes each of
+// their functions to set them within their respective configs.
+func invokeOptions(opts []config.Option) {
+	// Invoke the options we're trying to test.
+	for _, value := range opts {
+		value()
+	}
+}
+
+// TestNoPRONOM makes sure that the InspectNoPronom flag is set for the
+// identifiers that use it.
+func TestInspectNoPRONOM(t *testing.T) {
+
+	opts := getOptions()
+	invokeOptions(opts)
+
+	if config.NoPRONOM() != false {
+		t.Errorf("LoC NoPRONOM default is incorrect: %t", config.NoPRONOM())
+	}
+	if config.GetWikidataNoPRONOM() != false {
+		t.Errorf("Wikidata NoPRONOM default is incorrect: %t", config.GetWikidataNoPRONOM())
+	}
+
+	*inspectNoPRONOM = true
+	opts = getOptions()
+	invokeOptions(opts)
+
+	if config.NoPRONOM() != true {
+		t.Errorf("LoC NoPRONOM not set as anticipated: %t", config.NoPRONOM())
+	}
+	if config.GetWikidataNoPRONOM() != true {
+		t.Errorf("Wikidata NoPRONOM not set as anticipated: %t", config.GetWikidataNoPRONOM())
+	}
+}


### PR DESCRIPTION
This affects LoC and Wikidata identifiers and enables users to
inspect how a signature is constructed for the Library of Congress
or Wikidata idenifiers without also compiling PRONOM signatures
into the identifier.

Connected to #182 