### PR TITLE
Enable glob functionality on Windows

### DIFF
--- a/cmd/sf/sf.go
+++ b/cmd/sf/sf.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -491,7 +492,13 @@ func main() {
 			ctxts <- ctx
 			identifyRdr(os.Stdin, ctx, ctxts, getCtx)
 		} else {
-			err = identify(ctxts, v, "", *coe, *nr, d, getCtx)
+			globs, err := filepath.Glob(v)
+			if err != nil {
+				log.Fatalln(fmt.Sprintf("[FATAL] bad glob pattern: %e", err))
+			}
+			for _, glob := range globs {
+				err = identify(ctxts, glob, "", *coe, *nr, d, getCtx)
+			}
 		}
 		if err != nil {
 			break


### PR DESCRIPTION
Small PR to enable glob function on Windows. It looks like the glob pattern just needs to be expanded first and then fed into identify through a loop (mirroring -f flag). 

Tested on Windows and Linux, both look equivalent. 