### PR TITLE
Return proper error when given file/directory not found

### DIFF
--- a/cmd/sf/sf.go
+++ b/cmd/sf/sf.go
@@ -492,16 +492,21 @@ func main() {
 			ctxts <- ctx
 			identifyRdr(os.Stdin, ctx, ctxts, getCtx)
 		} else {
-			globs, err := filepath.Glob(v)
+			matches, err := filepath.Glob(v)
 			if err != nil {
 				log.Fatalf("[FATAL] bad glob pattern: %s\n", err)
 			}
-			for _, glob := range globs {
-				err = identify(ctxts, glob, "", *coe, *nr, d, getCtx)
+
+			if matches == nil {
+				log.Fatalf("[FATAL] no matching file or directory for '%s'\n", v)
+			}
+
+			for _, match := range matches {
+				err = identify(ctxts, match, "", *coe, *nr, d, getCtx)
 				if err != nil {
 					printFile(ctxts,
-						getCtx(glob, "", time.Time{}, 0),
-						fmt.Errorf("failed to identify %s: %v", glob, err))
+						getCtx(match, "", time.Time{}, 0),
+						fmt.Errorf("failed to identify %s: %v", match, err))
 					err = nil
 				}
 			}


### PR DESCRIPTION
This fixes #220, which has been introduced with the recent changes to support glob arguments internally.

An explicit check for no matches was missing, which I added to return a fatal error. The message reads in a way that suggests that matching was involved instead of just saying "not found", is that OK?

If I'm not missing anything the possibility to supply glob patterns when the shell doesn't already expand them isn't yet mentioned in the README or documentation, should this be added?