### PR TITLE
Partially revert glob support to Windows-only fallback

### DIFF
--- a/cmd/sf/longpath.go
+++ b/cmd/sf/longpath.go
@@ -27,6 +27,11 @@ func retryOpen(path string, err error) (*os.File, error) {
 	return nil, err
 }
 
+func tryStat(path string) error {
+	_, err := os.Lstat(path)
+	return err
+}
+
 func identify(ctxts chan *context, root, orig string, coerr, norecurse, droid bool, gf getFn) error {
 	walkFunc := func(path string, info os.FileInfo, err error) error {
 		if *throttlef > 0 {

--- a/cmd/sf/longpath_windows.go
+++ b/cmd/sf/longpath_windows.go
@@ -53,6 +53,16 @@ func shortpath(long, short string) string {
 	return long[i:]
 }
 
+
+func tryStat(path string) error {
+	_, err := os.Lstat(path)
+	if err != nil {
+		_, err = retryStat(path, err)
+	}
+
+	return err
+}
+
 func retryStat(path string, err error) (os.FileInfo, error) {
 	if strings.HasPrefix(path, prefix) { // already a long path - no point retrying
 		return nil, err

--- a/cmd/sf/sf.go
+++ b/cmd/sf/sf.go
@@ -494,10 +494,10 @@ func main() {
 			ctxts <- ctx
 			identifyRdr(os.Stdin, ctx, ctxts, getCtx)
 		} else {
-			_, err = os.Lstat(v)
-			if err != nil {
-				// As a workaround for https://github.com/richardlehane/siegfried/issues/227 only do glob matching on Windows _after_ a direct match has been tried and the name contains characters that indicate a possible pattern
-				if runtime.GOOS == "windows" && strings.ContainsAny(v, "*?[\\") {
+			// As a workaround for https://github.com/richardlehane/siegfried/issues/227 only do glob matching on Windows _after_ a direct match has been tried and the name contains characters that indicate a possible pattern
+			if runtime.GOOS == "windows" && strings.ContainsAny(v, "*?[\\") {
+				_, err = os.Lstat(v)
+				if err != nil {
 					// Since patterns aren't assumed to be the main argument form and a bad pattern can still be a valid filename (e.g. `file[.txt`) that just wasn't found ignore the returned error and just handle found matches
 					matches, _ := filepath.Glob(v)
 					if matches != nil {
@@ -511,15 +511,15 @@ func main() {
 
 						continue
 					}
-				}
 
-				break
-			} else {
-				err = identify(ctxts, v, "", *coe, *nr, d, getCtx)
-				if err != nil {
-					printFile(ctxts, getCtx(v, "", time.Time{}, 0), fmt.Errorf("failed to identify %s: %v", v, err))
-					err = nil
+					break
 				}
+			}
+
+			err = identify(ctxts, v, "", *coe, *nr, d, getCtx)
+			if err != nil {
+				printFile(ctxts, getCtx(v, "", time.Time{}, 0), fmt.Errorf("failed to identify %s: %v", v, err))
+				err = nil
 			}
 		}
 	}


### PR DESCRIPTION
This implements the approach discussed in #227 to remedy the reported regression by reverting to treating arguments as literal paths first and only on Windows attempting to match glob patterns when no direct match has been found.

I decided to implement the Windows-only behavior by checking against `runtime.GOOS` which is statically compiled into the executable as well and made more sense to me in this context than splitting this up across files. If you prefer I can certainly do that too. Also, to reduce the cases where a matching is attempted a bit I added a check for the relevant characters that could mark a valid pattern in the name.

I retained the changed `matches`/`match` variable names from #225 (which this PR subsumes) as you indicated you were fine with it, hope I got that right.

As already discussed, this won't solve all of the potentially surprising cases but will help for the most urgent and reported ones, we can keep further discussion for those in the original issue or open a separate one as you prefer. Seeing https://github.com/sul-dlss/technical-metadata-service/issues/437#issuecomment-1512236617 I'm slightly worried that there could already be more users that adjusted their integrations to shell-escape the arguments which they will have to revert should this PR get merged and eventually released.

Finally, I was wondering about whether the `*coe` "continue on errors" flag should have an effect on error handling across arguments and matches in addition to just the walk-function? I didn't add anything in this direction here, as this will be better discussed separately, just leaving this here for now while it's fresh in my head.