### PR TITLE
Hard-code compression algorithm for Debian package

### DIFF
--- a/debbuilder.sh
+++ b/debbuilder.sh
@@ -27,5 +27,9 @@ Priority: optional
 Description: signature-based file identification tool
 EOA
 
-# make deb
-dpkg-deb --build $SF_PATH
+# make deb; explicit 'xz' is for compatibility with Debian "bullseye";
+# see:
+#
+#    https://github.com/richardlehane/siegfried/issues/222
+#
+dpkg-deb -Zxz --build $SF_PATH


### PR DESCRIPTION
Motivation:

Newer Ubuntu releases have changed the default compression from xz to zstd.  The zstd compression is not supported by dpkg in "bullseye", the current stable release of Debian.

Modification:

Hard-code the compression algorithm to use the xz algorithm.

Result:

The debbuilder.sh script now produces packages that are compatible with Debian stable/bullseye.

Closes: #222