### PR TITLE
Update README.md - fix wasm/README.md path in changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Or, for the most recent updates, you can install from this fork:
 ## Changes
 ### v1.11.1 (2024-06-28)
 ### Added
-- WASM build. See pkg/wasm/README.md for more details. Feature sponsored by Archives New Zealand. Inspired by [Andy Jackson](https://siegfried-js.glitch.me/)
+- WASM build. See wasm/README.md for more details. Feature sponsored by Archives New Zealand. Inspired by [Andy Jackson](https://siegfried-js.glitch.me/)
 - `-sym` flag enables following symbolic links to files during scanning. Requested by [Max Moser](https://github.com/richardlehane/siegfried/issues/245) 
 
 ### Changed


### PR DESCRIPTION
i was looking for more info on the WASM version and noticed the wrong path in the changelog :) 