### PR TITLE
Introduce more context to logging

### DIFF
--- a/cmd/roy/roy.go
+++ b/cmd/roy/roy.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/richardlehane/siegfried"
 	"github.com/richardlehane/siegfried/internal/chart"
+	"github.com/richardlehane/siegfried/internal/logformatter"
 	"github.com/richardlehane/siegfried/pkg/config"
 	"github.com/richardlehane/siegfried/pkg/core"
 	"github.com/richardlehane/siegfried/pkg/loc"
@@ -115,6 +116,18 @@ Additional flags:
    -home
       Use a different siegfried home directory.
 `
+
+func setLogger(utc bool) {
+	lw := new(logformatter.LogWriter)
+	lw.Appname = "roy"
+	lw.UTC = utc
+	log.SetOutput(lw)
+}
+
+func init() {
+	// format the application logger before all other init.
+	setLogger(true)
+}
 
 var (
 	// BUILD, ADD flag sets

--- a/cmd/sf/sf.go
+++ b/cmd/sf/sf.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/richardlehane/siegfried"
 	"github.com/richardlehane/siegfried/internal/checksum"
+	"github.com/richardlehane/siegfried/internal/logformatter"
 	"github.com/richardlehane/siegfried/internal/logger"
 	"github.com/richardlehane/siegfried/pkg/config"
 	"github.com/richardlehane/siegfried/pkg/core"
@@ -41,6 +42,18 @@ import (
 
 // defaults
 const maxMulti = 1024
+
+func setLogger(utc bool) {
+	lw := new(logformatter.LogWriter)
+	lw.Appname = "sf"
+	lw.UTC = utc
+	log.SetOutput(lw)
+}
+
+func init() {
+	// format the application logger before all other init.
+	setLogger(true)
+}
 
 // flags
 var (

--- a/internal/logformatter/log.go
+++ b/internal/logformatter/log.go
@@ -1,0 +1,39 @@
+package logformatter
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+type LogWriter struct {
+	Appname string
+	UTC     bool
+}
+
+const logTimeFormat = "2006-01-02 15:04:05"
+
+// Write enables us to format a logging prefix for the application. The
+// text will appear before the log message output by the caller.
+//
+// e.g.
+//
+//	`// 2023-11-27 11:36:57 ERROR :: golang-app:100:main() :: this is an error message, ...some diagnosis`
+func (lw *LogWriter) Write(logString []byte) (int, error) {
+	logTime := time.Now().UTC().Format(logTimeFormat)
+	if !lw.UTC {
+		logTime = time.Now().Format(logTimeFormat)
+	}
+	return fmt.Fprintf(os.Stderr, "%s :: %s :: %s",
+		logTime,
+		lw.Appname,
+		string(logString),
+	)
+}
+
+func init() {
+	// Configure logging to use a custom log writer with sensible defaults.
+	log.SetFlags(0 | log.Lshortfile | log.LUTC)
+	log.SetOutput(new(LogWriter))
+}


### PR DESCRIPTION
A new log formatter is introduced that adds program contex to the log output, e.g. source file, and line of code where a log call is made. Additional program context can be added consistently. Datetime is formatted in ISO format and an option is provided to use UTC or local timezones.

Log formatting now looks more like as follows:

```
r0ss@exponential-decay:~/git/richardlehane/siegfried/cmd/roy$ ./roy harvest
2024-08-03 13:26:06 :: roy :: roy.go:658: roy: errors saving reports to disk [open : no such file or directory]

r0ss@exponential-decay:~/git/richardlehane/siegfried/cmd/roy$ ./roy build
2024-08-03 13:32:20 :: roy :: roy.go:658: pronom: error loading containers; got open : no such file or directory
Unless you have set `-nocontainer` you need to download a container signature file

r0ss@exponential-decay:~/git/richardlehane/siegfried/cmd/sf$ ./sf
2024-08-03 13:37:10 :: sf :: sf.go:477: [FATAL] expecting one or more file or directory arguments (or '-' to scan stdin)
```

versus;

```
r0ss@exponential-decay:~/git/richardlehane/siegfried/cmd/sf$ ./sf
2024/08/03 15:49:38 [FATAL] expecting one or more file or directory arguments (or '-' to scan stdin)

r0ss@exponential-decay:~/git/richardlehane/siegfried/cmd/roy$ ./roy build
2024/08/03 15:49:29 pronom: error loading containers; got open : no such file or directory
Unless you have set `-nocontainer` you need to download a container signature file
```

In future commits, log messages can be modified to remove manually entered references to "roy" or "sf". 

One question might be to set datetime to UTC by default or not. I've started using the former in most codebases. Folks may still prefer local.