### PR TITLE
Update definitions name to 4.0.0

### DIFF
--- a/pkg/config/wikidata.go
+++ b/pkg/config/wikidata.go
@@ -106,7 +106,7 @@ var wikidata = struct {
 	gzip:                   "Q27824060",
 	tar:                    "Q283579",
 	warc:                   "Q10287816",
-	definitions:            "wikidata-definitions-3.0.0",
+	definitions:            "wikidata-definitions-4.0.0",
 	endpoint:               "https://query.wikidata.org/sparql",
 	filemode:               0644,
 	propPronom:             "http://www.wikidata.org/entity/Q35432091",


### PR DESCRIPTION
With the change to 09ca73af it helps to differentiate Wikidata output. We do that here by upping the version number saved to disk.