### PR TITLE
Support explicitly declared variable length offsets

### DIFF
--- a/pkg/pronom/parse.go
+++ b/pkg/pronom/parse.go
@@ -161,9 +161,10 @@ func processDROID(puid string, s []mappings.ByteSeq) (frames.Signature, error) {
 	for _, b := range s {
 		var eof, vry bool
 		ref := b.Reference
-		if ref == droideof {
+		switch ref {
+		case droideof:
 			eof = true
-		} else if ref == "" {
+		case "Variable", "":
 			vry = true
 		}
 		var zeroIndexed bool // fmt/1190 bug in containers: https://github.com/richardlehane/siegfried/issues/175


### PR DESCRIPTION
A `<ByteSequence>` without a `Reference=...` attribute was previously assumed to implicitly indicate a variable length offset; however, variable length offsets may also be declared _explicitly_ using `Reference="Variable"`. The only file format that currently uses this explicit form is [WACZ](https://specs.webrecorder.net/wacz/1.1.1/) (fmt/1840):

```xml
<!-- from https://cdn.nationalarchives.gov.uk/documents/container-signature-20240715.xml --> 
<ContainerSignature Id="80000" ContainerType="ZIP">
    <Description>Web Archive Collection Zipped</Description>
    <Files>
        <File>
            <Path>datapackage.json</Path>
            <BinarySignatures>
                <InternalSignatureCollection>
                    <InternalSignature ID="80000">
                        <ByteSequence Reference="Variable">
                            <SubSequence Position="1">
                                <Sequence>'wacz_version'</Sequence>
                            </SubSequence>
                        </ByteSequence>
              ...
```


With this commit, `siegfried` can now thus differentiate WACZ from ZIP files — provided, at least, that you are also using a container signature file released in 2024 or later.  

I can take a look at adding support for WACZ files in siegried later as well, since both WACZ and siegfried are important for some projects I'm working on!