### PR TITLE
Enable noprov in wikidata revision history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ ehthumbs.db
 Thumbs.db
 fmt-649-signature-id-977.mpg
 fmt-640-signature-id-969.mpg
+cmd/roy/roy
+cmd/sf/sf
+roy.exe
+sf.exe

--- a/cmd/roy/harvest_wikidata.go
+++ b/cmd/roy/harvest_wikidata.go
@@ -69,7 +69,7 @@ func addEndpoint(repl string, endpoint string) string {
 
 // harvestWikidata will connect to the configured Wikidata query service
 // and save the results of the configured query to disk.
-func harvestWikidata() error {
+func harvestWikidata(provenance bool) error {
 
 	log.Printf(
 		"harvesting Wikidata definitions: lang '%s'",
@@ -91,16 +91,23 @@ func harvestWikidata() error {
 	// and api.php links for permalinks and revision history.
 	wikiprov.SetWikibaseURLs(config.WikidataWikibaseURL())
 
-	log.Printf(
-		"harvesting revision history from: '%s'",
-		config.WikidataWikibaseURL(),
-	)
+	if !*wikidataRevisionHistory {
+		log.Printf(
+			"harvesting revision history from: '%s'",
+			config.WikidataWikibaseURL(),
+		)
+	}
+
+	historyLength := config.GetWikidataRevisionHistoryLen()
+	if !provenance {
+		historyLength = 0
+	}
 
 	res, err := spargo.SPARQLWithProv(
 		config.WikidataEndpoint(),
 		config.WikidataSPARQL(),
 		config.WikidataSPARQLRevisionParam(),
-		config.GetWikidataRevisionHistoryLen(),
+		historyLength,
 		config.GetWikidataRevisionHistoryThreads(),
 	)
 

--- a/cmd/roy/harvest_wikidata.go
+++ b/cmd/roy/harvest_wikidata.go
@@ -72,18 +72,18 @@ func addEndpoint(repl string, endpoint string) string {
 func harvestWikidata() error {
 
 	log.Printf(
-		"Roy (Wikidata): Harvesting Wikidata definitions: lang '%s'",
+		"harvesting Wikidata definitions: lang '%s'",
 		config.WikidataLang(),
 	)
 	err := os.MkdirAll(config.WikidataHome(), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf(
-			"Roy (Wikidata): Error harvesting Wikidata definitions: '%s'",
+			"error harvesting Wikidata definitions: '%s'",
 			err,
 		)
 	}
 	log.Printf(
-		"Roy (Wikidata): Harvesting definitions from: '%s'",
+		"harvesting definitions from: '%s'",
 		config.WikidataEndpoint(),
 	)
 
@@ -92,7 +92,7 @@ func harvestWikidata() error {
 	wikiprov.SetWikibaseURLs(config.WikidataWikibaseURL())
 
 	log.Printf(
-		"Roy (Wikidata): Harvesting revision history from: '%s'",
+		"harvesting revision history from: '%s'",
 		config.WikidataWikibaseURL(),
 	)
 
@@ -130,7 +130,7 @@ func harvestWikidata() error {
 		)
 	}
 	log.Printf(
-		"Roy (Wikidata): Harvesting Wikidata definitions '%s' complete",
+		"harvesting Wikidata definitions '%s' complete",
 		path,
 	)
 	return nil

--- a/cmd/roy/roy.go
+++ b/cmd/roy/roy.go
@@ -170,6 +170,7 @@ var (
 	harvestWikidataLang        = harvest.String("lang", config.WikidataLang(), "two-letter language-code to download Wikidata strings, e.g. \"de\"")
 	harvestWikidataEndpoint    = harvest.String("wikidataendpoint", config.WikidataEndpoint(), "the endpoint to use to harvest Wikidata definitions from")
 	harvestWikidataWikibaseURL = harvest.String("wikibaseurl", config.WikidataWikibaseURL(), "the permalink baseURL for the Wikibase server")
+	wikidataRevisionHistory    = harvest.Bool("noprov", false, "turn Wikidata revision history off")
 
 	// INSPECT (roy inspect | roy inspect fmt/121 | roy inspect usr/local/mysig.sig | roy inspect 10)
 	inspect         = flag.NewFlagSet("inspect", flag.ExitOnError)
@@ -509,7 +510,7 @@ func setHarvestOptions() {
 	if *harvestWikidataEndpoint != config.WikidataEndpoint() {
 		// Configure Siegfried to connect to a custom Wikibase instance.
 		if err := configureCustomWikibase(); err != nil {
-			log.Printf("Roy (Wikibase): %s", err)
+			log.Printf("wikibase: %s", err)
 			os.Exit(1)
 		}
 	}
@@ -563,7 +564,9 @@ func main() {
 			if *harvestChanges {
 				err = pronom.GetReleases(config.Local("release-notes.xml"))
 			} else if *harvestWikidataSig {
-				err = harvestWikidata()
+				history := !*wikidataRevisionHistory
+				log.Printf("retrieving history for Wikidata: %t", history)
+				err = harvestWikidata(history)
 			} else {
 				err = savereps()
 			}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/richardlehane/mscfb v1.0.4
 	github.com/richardlehane/webarchive v1.0.3
 	github.com/richardlehane/xmldetect v1.0.2
-	github.com/ross-spencer/wikiprov v0.2.0
+	github.com/ross-spencer/wikiprov v1.0.0
 	golang.org/x/image v0.18.0
 	golang.org/x/sys v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,10 @@ github.com/ross-spencer/spargo v0.4.1 h1:+a570tI+az8j/s0+06mntNqwsJ7DXuq7PESUIXl
 github.com/ross-spencer/spargo v0.4.1/go.mod h1:szEHC5cu+q6g0RD7otV7xvYGb+fQVYj1/SkiVTr4IC4=
 github.com/ross-spencer/wikiprov v0.2.0 h1:I0RAdlgVW5z2sMk/vAPS5cXTbIsMNAnYEIAS+CZ4urE=
 github.com/ross-spencer/wikiprov v0.2.0/go.mod h1:a7GkJgwKK3D2DlrGindbHR2VciEbHHCl6fFAKaiRhVI=
+github.com/ross-spencer/wikiprov v1.0.0-rc1 h1:I2/p6lEWQdxCWPmvURWCp8/abiHlQXmP2zBzxZpWncc=
+github.com/ross-spencer/wikiprov v1.0.0-rc1/go.mod h1:a7GkJgwKK3D2DlrGindbHR2VciEbHHCl6fFAKaiRhVI=
+github.com/ross-spencer/wikiprov v1.0.0 h1:tbDg/pFVPsaTXVXFp7lkeMjr5icFklFeRla2sh+Zl6E=
+github.com/ross-spencer/wikiprov v1.0.0/go.mod h1:Fz4skf6LE/1iGHOE/mM23DcZBAVGlaC96NTqNoZWs44=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=

--- a/pkg/config/wikidata.go
+++ b/pkg/config/wikidata.go
@@ -308,6 +308,12 @@ func GetWikidataRevisionHistoryLen() int {
 	return wikidata.revisionHistoryLen
 }
 
+// GetWikidataRevisionHistoryLen will return the length of the Wikibase
+// history to retrieve to the caller.
+func SetWikidataRevisionHistoryLen(len int) int {
+	return wikidata.revisionHistoryLen
+}
+
 // GetWikidataRevisionHistoryThreads will return the number of threads
 // to use to retrieve Wikibase history to the caller.
 func GetWikidataRevisionHistoryThreads() int {

--- a/pkg/wikidata/identifier.go
+++ b/pkg/wikidata/identifier.go
@@ -61,10 +61,10 @@ func New(opts ...config.Option) (core.Identifier, error) {
 	for _, v := range opts {
 		v()
 	}
-	logln("Roy (Wikidata): Congratulations: doing something with the Wikidata identifier package!")
+	logln("congratulations: doing something with the Wikidata identifier package!")
 	wikidata, puids, err := newWikidata()
 	if err != nil {
-		return nil, fmt.Errorf("Error in Wikidata New(): %w", err)
+		return nil, fmt.Errorf("error in Wikidata New(): %w", err)
 	}
 	// Having retrieved our PUIDs from newWikidata, assign them to our
 	// provenance global to generate source information from Wikidata.

--- a/pkg/wikidata/load_wikidata.go
+++ b/pkg/wikidata/load_wikidata.go
@@ -141,7 +141,7 @@ func customEndpoint(jsonFile []byte) (bool, error) {
 // identifier to be consumed by Siegfried.
 func openWikidata() (wikiItemProv, error) {
 	path := config.WikidataDefinitionsPath()
-	logf("Roy (Wikidata): Opening Wikidata definitions: %s\n", path)
+	logf("opening Wikidata definitions: %s\n", path)
 	jsonFile, err := ioutil.ReadFile(path)
 	if err != nil {
 		return wikiItemProv{}, fmt.Errorf(
@@ -154,23 +154,23 @@ func openWikidata() (wikiItemProv, error) {
 		return wikiItemProv{}, err
 	}
 	if custom {
-		logln("Roy (Wikidata): Using a custom endpoint for results")
+		logln("using a custom endpoint for results")
 		err := setCustomWikibaseProperties()
 		if err != nil {
 			return wikiItemProv{}, fmt.Errorf("setting custom Wikibase properties: %w", err)
 		}
 		logf(
-			"Roy (Wikidata): Custom PRONOM encoding loaded; config: '%s' => local: '%s'",
+			"custom PRONOM encoding loaded; config: '%s' => local: '%s'",
 			config.WikibasePronom(),
 			converter.GetPronomEncoding(),
 		)
 		logf(
-			"Roy (Wikidata): Custom BOF loaded; config: '%s' => local: '%s'",
+			"custom BOF loaded; config: '%s' => local: '%s'",
 			config.WikibaseBOF(),
 			relativeBOF,
 		)
 		logf(
-			"Roy (Wikidata): Custom EOF loaded; config: '%s' => local: '%s'",
+			"custom EOF loaded; config: '%s' => local: '%s'",
 			config.WikibaseEOF(),
 			relativeEOF,
 		)
@@ -267,7 +267,7 @@ const (
 // setCustomWikibaseProperties sets the properties needed by Roy to
 // parse the results coming from a custom Wikibase endpoint.
 func setCustomWikibaseProperties() error {
-	logln("Roy (Wikidata): Looking for existence of wikibase.json in Siegfried home")
+	logln("looking for existence of wikibase.json in Siegfried home")
 	wikibasePropsPath := config.WikibasePropsPath()
 	propsFile, err := os.ReadFile(wikibasePropsPath)
 	if err != nil {
@@ -306,7 +306,7 @@ func setCustomWikibaseProperties() error {
 	GetPronomURIFromConfig()
 	GetBOFandEOFFromConfig()
 	logf(
-		"Roy (Wikidata): Properties set for PRONOM: '%s', BOF: '%s', EOF: '%s'",
+		"properties set for PRONOM: '%s', BOF: '%s', EOF: '%s'",
 		pronom,
 		bof,
 		eof,

--- a/pkg/wikidata/signature_file_operations.go
+++ b/pkg/wikidata/signature_file_operations.go
@@ -128,12 +128,16 @@ func (f formatInfo) String() string {
 	if len(f.sources) > 0 {
 		sources = strings.Join(f.sources, " ")
 	}
+	var revisionHistory string = f.revisionHistory
+	if f.revisionHistory == "" {
+		revisionHistory = "not collected for this QID"
+	}
 	return fmt.Sprintf(
-		"Name: '%s'\nMIMEType: '%s'\nSources: '%s' \nRevision History: %s\n---",
+		"Name: '%s'\nMIMEType: '%s'\nSources: '%s' \nRevision History: %s",
 		f.name,
 		f.mime,
 		sources,
-		f.revisionHistory,
+		revisionHistory,
 	)
 }
 

--- a/pkg/wikidata/signature_file_operations.go
+++ b/pkg/wikidata/signature_file_operations.go
@@ -144,7 +144,7 @@ func (f formatInfo) String() string {
 // formats that you'd like to talk about in an identifier.
 func (wdd wikidataDefinitions) Infos() parseableFormatInfo {
 	logf(
-		"Roy (Wikidata): In Infos()... length formats: '%d' no-pronom: '%t'\n",
+		"in Infos()... length formats: '%d' no-pronom: '%t'\n",
 		len(wdd.formats),
 		config.GetWikidataNoPRONOM(),
 	)

--- a/pkg/wikidata/signature_operations.go
+++ b/pkg/wikidata/signature_operations.go
@@ -35,7 +35,7 @@ import (
 // to match formats by that.
 func (wdd wikidataDefinitions) Globs() ([]string, []string) {
 	logln(
-		"Roy (Wikidata): Adding Glob signatures to identifier...",
+		"adding Glob signatures to identifier...",
 	)
 	globs, ids := make(
 		[]string, 0, len(wdd.formats)),
@@ -103,7 +103,7 @@ func processForPronom(bs byteSequences) []pronomSequence {
 // collected along the way.
 func processSIgnatures(wdd wikidataDefinitions) ([]frames.Signature, []string, error) {
 	logln(
-		"Roy (Wikidata): Adding Wikidata Byte signatures to identifier...",
+		"adding Wikidata byte signatures to identifier...",
 	)
 	var errs []error
 	var puidsIDs map[string][]string
@@ -170,7 +170,7 @@ func (wdd wikidataDefinitions) MSCFBs() ([][]string, [][]frames.Signature, []str
 // Wikidata container modeling is in-progress.
 func (wdd wikidataDefinitions) containers(typ string) ([][]string, [][]frames.Signature, []string, error) {
 	logln(
-		"Roy (Wikidata): Adding container signatures to identifier...",
+		"adding container signatures to identifier...",
 	)
 	if _, ok := wdd.parseable.(identifier.Blank); ok {
 		return nil, nil, nil, nil

--- a/pkg/wikidata/wikidata.go
+++ b/pkg/wikidata/wikidata.go
@@ -56,11 +56,11 @@ func newWikidata() (identifier.Parseable, []string, error) {
 	}
 	if config.GetWikidataNoPRONOM() {
 		logln(
-			"Roy (Wikidata): Not building identifiers set from PRONOM",
+			"not building identifiers set from PRONOM",
 		)
 	} else {
 		logln(
-			"Roy (Wikidata): Building identifiers set from PRONOM",
+			"building identifiers set from PRONOM",
 		)
 		wikiParseable, err = pronom.NewPronom()
 		if err != nil {

--- a/pkg/wikidata/wikidata_process_records.go
+++ b/pkg/wikidata/wikidata_process_records.go
@@ -43,7 +43,7 @@ func getProvenance(id string, provenance wikiProv) (string, string, error) {
 			return value.Permalink, fmt.Sprintf("%s", value), nil
 		}
 	}
-	return noValueFound, noValueFound, fmt.Errorf("Roy (Wikidata): Provenance not found for: %s", id)
+	return noValueFound, noValueFound, fmt.Errorf("provenance not found for: %s", id)
 }
 
 // newRecord creates a Wikidata record with the values received from
@@ -78,7 +78,9 @@ func newRecord(wikidataItem map[string]spargo.Item, provenance wikiProv, addSigs
 	}
 	perma, prov, err := getProvenance(wd.ID, provenance)
 	if err != nil {
-		logln("Roy (Wikidata):", err) // Q. (RL) Is it safe to ignore this error and just log it? Or should this func return an error?
+		// ideally convert this to a debug log in future as it
+		// can be verbose when logging is entirely off.
+		logln(err)
 	}
 	wd.Permalink, wd.RevisionHistory = perma, prov
 	return wd


### PR DESCRIPTION
Should probably sit in dev branch for a while. 

* Updates wikiprov.
* Adds `-noprov` flag (revision history is still default, but friendlier to Wikidata's Wikibase). NB. input on names appreciated.
* Simplifies logging thanks to b27db87.
* Adds binaries to .gitignore.

Relies on https://github.com/ross-spencer/wikiprov/pull/8
Resolves: https://github.com/richardlehane/siegfried/issues/183

## how to test

As-is: 

```sh
./roy harvest -wikidata
```

Without provenance:

```sh
./roy harvest -wikidata -noprov
```

Building:

```sh
./roy build -wikidata -nopronom
```

Testing inspect:

```sh
./roy inspect -nopronom -wikidata Q42591
```
