### PR TITLE
Separate Go minimum and release versions

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: richardlehane/provisioner
-      - name: Install latest version of go
+      - name: Install preferred Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Install latest version of go
+      - name: Install preferred Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Install latest version of go
+      - name: Install preferred Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Install latest version of go
+      - name: Install preferred Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
@@ -124,7 +124,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Install latest version of go
+      - name: Install preferred Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
@@ -150,7 +150,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Install latest version of go
+      - name: Install preferred Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,14 +12,18 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      # Test the matrix-selected toolchain instead of switching to the
+      # preferred toolchain from go.mod.
+      GOTOOLCHAIN: local
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go: [ '1.x', '1.25']
+        go: [stable, oldstable]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Install latest version of go
+      - name: Install matrix Go toolchain
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## Unreleased
+### Changed
+- build releases with Go 1.26.5; minimum Go version for library users is still 1.25.0
+
 ## v1.11.5 (2026-07-11)
 ### Changed 
 - update PRONOM to v124

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/richardlehane/siegfried
 
 go 1.25.0
 
+toolchain go1.26.5
+
 require (
 	github.com/richardlehane/characterize v1.0.0
 	github.com/richardlehane/match v1.0.5


### PR DESCRIPTION
This change keeps Go 1.25.0 as the minimum version for people using siegfried as a library, while release binaries are built with Go 1.26.5. Building new binaries with the first, unpatched Go 1.25 release was missing many security fixes and compiler/runtime improvements for no real benefit.

CI now covers the latest patches of both officially supported Go releases (`stable` and `oldstable`). `GOTOOLCHAIN=local` ensures that the oldstable job really uses Go 1.25 instead of silently switching to the preferred Go 1.26.5 toolchain.